### PR TITLE
Deploy slides to GH Pages

### DIFF
--- a/.github/workflows/gp-deploy.yml
+++ b/.github/workflows/gp-deploy.yml
@@ -1,10 +1,9 @@
 name: Github Pages deploy
-# on:
-#   push:
-#     branches:
-#       - "main"
+on:
+  push:
+    branches:
+      - "main"
 
-on: [push]
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/gp-deploy.yml
+++ b/.github/workflows/gp-deploy.yml
@@ -1,0 +1,29 @@
+name: Github Pages deploy
+# on:
+#   push:
+#     branches:
+#       - "main"
+
+on: [push]
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Install and Build 🔧
+        run: |
+          yarn
+          yarn build
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.4
+        with:
+          branch: gh-pages
+          folder: dist


### PR DESCRIPTION
This PR adds Github workflows to deploy the slides to Github Pages. Every push to `main` branch will re-deploy the slides.

This requires some manual steps - looks like I don't have admin/owner permissions on the repo.
We need to follow this steps: https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site.
- branch: `gh-pages`
- folder: `root`